### PR TITLE
Upgrade to last versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.207
+FROM jenkins/jenkins:2.222.1
 
 USER jenkins
 

--- a/DockerfileSlave
+++ b/DockerfileSlave
@@ -5,13 +5,13 @@ FROM jenkinsci/jnlp-slave:3.35-2-jdk11
 USER root
 
 RUN apt-get update \
-    && apt-get install -y apt-transport-https ca-certificates \
-    && apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D \
-    && echo deb https://apt.dockerproject.org/repo debian-stretch main >> /etc/apt/sources.list.d/docker.list \
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian stretch stable" \
     && apt-get update \
-    && apt-get install -y docker-engine \
+    && apt-get install -y docker-ce docker-ce-cli containerd.io \
     && apt-get install -y btrfs-tools \
-    && apt-get install openjdk-11-jdk-headless \
+    && apt-get install -y openjdk-11-jdk-headless \
     && rm -rf /var/lib/apt/lists/*
 
 ADD launch-slave /root/

--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -50,9 +50,9 @@ tool:
     installations:
       - name: "maven"
         properties:
-          - installSourceProperty:
+          - installSource:
               installers:
-              - mavenInstaller:
+              - maven:
                   id: 3.6.0
   sbtInstallation:
     installations:

--- a/plugins.txt
+++ b/plugins.txt
@@ -1,6 +1,6 @@
-configuration-as-code:1.35
-gatling:1.2.7
-git:4.1.1
-job-dsl:1.76
+configuration-as-code:1.39
+gatling:1.3.0
+git:4.2.2
+job-dsl:1.77
 workflow-aggregator:2.6
 sbt:1.5


### PR DESCRIPTION
- upgrade docker installation process (previous repository was no more available)
- fix security warnings and upgrade all plugins